### PR TITLE
(v2) reject when empty array of roles is provided

### DIFF
--- a/lib/rbac.js
+++ b/lib/rbac.js
@@ -98,6 +98,10 @@ RBAC.prototype.can = function can(role, operation, params, cb) {
     }
 
     if(Array.isArray(role)) {
+        if(role.length < 1) {
+          return Promise.reject(new RangeError('Expected first parameter to be string | (non-empty) Array<String>: role'));
+        }
+
         promise = Q.any(role.map(function (r) {
           return $this.can(r, operation, params);
         }));

--- a/test/async.test.js
+++ b/test/async.test.js
@@ -385,6 +385,17 @@ describe('RBAC async', function() {
             });
         });
 
+        it('should reject empty roles', function (done) {
+          (new RBAC(function (cb) { setTimeout(cb, 100, null, data.multiRole) }))
+            .can([], 'resource:action')
+            .then(function () {
+              done(new Error('should be rejected'));
+            })
+            .catch(function () {
+              done();
+            });
+        });
+
         it('should reject non-string role', function (done) {
           (new RBAC(function (cb) { setTimeout(cb, 100, null, data.multiRole) }))
             .can([{}], 'resource:action')

--- a/test/sync.test.js
+++ b/test/sync.test.js
@@ -328,6 +328,16 @@ describe('RBAC sync', function() {
           });
       });
 
+      it('should reject empty roles', function (done) {
+        rbac.can([], 'resource:action')
+          .then(function () {
+            done(new Error('should be rejected'));
+          })
+          .catch(function () {
+            done();
+          });
+      });
+
       it('should reject non-string role', function (done) {
         rbac.can([{}], 'resource:action')
           .then(function () {


### PR DESCRIPTION
`.can` resolves without issue if called with an empty roles array. 

I've added tests for sync/async for this case.

I don't know if this is an issue for v3 as I'm not on node8 to test. 